### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           UPGRADE_TEST_OLD_PROXY: ${{ secrets.UPGRADE_TEST_OLD_PROXY }}
           UPGRADE_TEST_OLD_VERSION: ${{ secrets.UPGRADE_TEST_OLD_VERSION }}
         run: |
-          forge test -vvv
+          forge test --rerun -vvvvv
 
       - name: Format contracts and generate snapshots
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## Summary by Sourcery

Enhance the CI test step to automatically rerun failed tests and increase verbosity in Forge.

CI:
- Enable the --rerun flag for Forge tests to retry failures automatically
- Increase Forge test verbosity from -vvv to -vvvvv