### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           UPGRADE_TEST_OLD_PROXY: ${{ secrets.UPGRADE_TEST_OLD_PROXY }}
           UPGRADE_TEST_OLD_VERSION: ${{ secrets.UPGRADE_TEST_OLD_VERSION }}
         run: |
-          forge test -vvv
+          forge test --no-match-contract UpgradeTests
 
       - name: Format contracts and generate snapshots
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use '--no-match-contract UpgradeTests' to exclude upgrade tests in CI test runs