### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -1,5 +1,8 @@
 name: Manual Deployment Execution
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/account/security/code-scanning/2](https://github.com/Dargon789/account/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions` block that scopes the GITHUB_TOKEN to the minimal permissions required by this workflow. This block can be placed either at the workflow root (applies to all jobs) or under the specific job (`deploy`). Here, there is only one job, so placing it at the top level is simple and clear.

The job needs to: check out the repository, upload artifacts, and write to the step summary. These only require `contents: read` (for `actions/checkout`) and do not require write access to repository contents or other resources. None of the shown steps use GitHub APIs that require write permissions (no issue/PR modifications, no publishing packages, etc.), and `upload-artifact` interacts with GitHub’s artifact service, not repository contents. Therefore, the safest and sufficient minimal configuration is:

```yaml
permissions:
  contents: read
```

To implement this without changing existing functionality, edit `.github/workflows/manual-deployment.yml` and add a `permissions` block at the top workflow level, just below the `name:` (and before `on:`). No new imports or external dependencies are needed, and no existing steps need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Define an explicit permissions block in the manual-deployment workflow, limiting access to read-only repository contents to address code scanning alerts.