### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     name: Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/account/security/code-scanning/4](https://github.com/Dargon789/account/security/code-scanning/4)

To fix the problem, explicitly declare a `permissions` block that grants only the minimal required permissions to the `GITHUB_TOKEN`. Since this workflow only checks out code, installs tools, builds, formats, tests, and compares snapshots locally without interacting with GitHub resources in a write capacity, it can safely run with `contents: read` only.

The best fix with no functional change is to add a job-level `permissions` block under the `test` job (or at the root). Following the CodeQL suggestion, set `contents: read`. Concretely, in `.github/workflows/ci.yaml`, between lines 10 and 11 (right after `name: Tests` and before `runs-on: ubuntu-latest`), insert:

```yaml
    permissions:
      contents: read
```

No additional methods, imports, or definitions are needed; this is purely a YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Declare minimal GITHUB_TOKEN permissions (contents: read) for the CI test job in .github/workflows/ci.yaml.