### PR TITLE
Revert "feat: add multicall to simulator (ithacaxyz#402) "

### DIFF
--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -34,7 +34,6 @@ contract BaseTest is SoladyTest {
     EIP7702Proxy eip7702Proxy;
     TargetFunctionPayload[] targetFunctionPayloads;
     Simulator simulator;
-    bytes32 contextKeyHash;
 
     struct TargetFunctionPayload {
         address by;
@@ -93,10 +92,6 @@ contract BaseTest is SoladyTest {
 
     function targetFunction(bytes memory data) public payable {
         targetFunctionPayloads.push(TargetFunctionPayload(msg.sender, msg.value, data));
-    }
-
-    function targetFunctionContextKeyHash() public payable {
-        contextKeyHash = IthacaAccount(payable(msg.sender)).getContextKeyHash();
     }
 
     function _setEIP7702Delegation(address eoa) internal {


### PR DESCRIPTION
Reverts Dargon789/account#24

## Summary by Sourcery

Revert context key hash test support introduced for the simulator multicall feature.

Tests:
- Remove Account context key hash integration test that exercised different execution workflows.
- Remove Base test helper state and function for retrieving and asserting the context key hash.