### PR TITLE
Add rerun option to forge test command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,9 +33,10 @@ jobs:
           UPGRADE_TEST_OLD_PROXY: ${{ secrets.UPGRADE_TEST_OLD_PROXY }}
           UPGRADE_TEST_OLD_VERSION: ${{ secrets.UPGRADE_TEST_OLD_VERSION }}
         run: |
-          forge test -vvv
-          Tip: Run `forge test --rerun` to retry only the 1 failed test
-
+          forge test 
+          #to retry only the 1 failed test
+          forge test --rerun
+          
       - name: Format contracts and generate snapshots
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the CI workflow to run `forge test --rerun` after the standard `forge test -vvv` step.