### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-infra.yml
+++ b/.github/workflows/test-infra.yml
@@ -1,4 +1,6 @@
 name: Manual Deployment Execution
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/account/security/code-scanning/3](https://github.com/Dargon789/account/security/code-scanning/3)

In general, the fix is to explicitly set `permissions` for the workflow or for the specific job so that the `GITHUB_TOKEN` has only the scopes it needs. For this workflow, the steps do not perform any GitHub API writes (no pushes, issue or PR updates, etc.), so `contents: read` is sufficient. `actions/checkout@v4` functions correctly with `contents: read` for a simple checkout, and the remaining steps rely only on secrets and the runner filesystem, not on `GITHUB_TOKEN`.

The best minimal change is to add a workflow-level `permissions` block just after the `name:` (before `on:`) in `.github/workflows/test-infra.yml`, setting `contents: read`. This applies to all jobs in the workflow (there is only `deploy`), and does not change functionality because the job only needs read access to the repo. No imports or additional methods are required.

Specifically, modify `.github/workflows/test-infra.yml` so that:

- After line 1 (`name: Manual Deployment Execution`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- Leave all other lines unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add a workflow-level permissions block to the test-infra GitHub Actions workflow limiting GITHUB_TOKEN to contents: read.