### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -17,6 +17,8 @@ jobs:
   check-permissions:
     name: Check permissions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       has-permission: ${{ steps.check.outputs.has-permission }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/account/security/code-scanning/1](https://github.com/Dargon789/account/security/code-scanning/1)

In general, to fix this type of issue you add an explicit `permissions` block either at the workflow root or on each job, setting the least privileges required. Jobs that only read repository metadata or use `github-script` for read-only queries typically only need `contents: read` (and sometimes no special scopes beyond the default `metadata: read`).

For this workflow, the `claude-assistant` job already has explicit (and intentionally broad) permissions, so we should not change that job. The flagged job is `check-permissions`, which uses `actions/github-script@v7` to call `github.rest.repos.getCollaboratorPermissionLevel`. That requires read access to repository contents/metadata, but no write access. The best fix is to add a `permissions` block under `check-permissions` with a minimal scope, e.g. `contents: read`. We keep everything else unchanged. Concretely, in `.github/workflows/claude-code.yml` under `jobs:`, inside `check-permissions:` and alongside `name:`, `runs-on:`, etc., add:

```yaml
    permissions:
      contents: read
```

This ensures the `GITHUB_TOKEN` for that job is limited to read-only repository contents, satisfying CodeQL and the principle of least privilege without affecting current functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Limit GITHUB_TOKEN scope for the check-permissions job in the claude-code workflow by explicitly setting contents: read permissions.